### PR TITLE
PLAT-752: Fix changelog assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 How to use it ?
 ```
-npx renovate-changelog-updater --depName my-updated-package --current-version 1.0.0 --new-version 2.0.0
+npx umbralab-renovate-changelog-updater --depName my-updated-package --current-version 1.0.0 --new-version 2.0.0 --is-lock-file-maintenance false
 ```
 
 How to configure renovate ?
 ```
 {
   allowPostUpgradeCommandTemplating: true,
-  allowedPostUpgradeCommands: ['^npx renovate-changelog-updater'],
+  allowedPostUpgradeCommands: ['^npx umbralab-renovate-changelog-updater'],
   postUpgradeTasks: {
-    commands: ['npx renovate-changelog-updater --depName {{{depName}}} --current-version {{{currentVersion}}} --new-version {{{newVersion}}}'],
+    commands: ['npx umbralab-renovate-changelog-updater --depName {{{depName}}} --current-version {{{currentVersion}}} --new-version {{{newVersion}}} --is-lock-file-maintenance {{{isLockFileMaintenance}}}'],
     fileFilters: ['CHANGELOG.md'],
     executionMode: 'update',
   }

--- a/index.js
+++ b/index.js
@@ -23,6 +23,11 @@ const parser = yargs(process.argv.slice(2))
       demandOption: true,
       describe: 'The new version of the updated package',
     },
+    'is-lock-file-maintenance': {
+      type: 'boolean',
+      demandOption: true,
+      describe: 'Whether or not the Renovate changes are lock file maintenance',
+    },
     format: {
       type: 'string',
       describe: 'The changelog format',
@@ -40,10 +45,10 @@ const parser = yargs(process.argv.slice(2))
       default: './CHANGELOG.md',
     },
   })
-  .example('$0 --dep-name my-updated-package --current-version 1.0.0 --new-version 2.0.0', '');
+  .example('$0 --dep-name my-updated-package --current-version 1.0.0 --new-version 2.0.0 --is-lock-file-maintenance false', '');
 
 (async () => {
-  const { format, path, depName, newVersion, currentVersion, ignoreFailure } = await parser.argv;
+  const { format, path, depName, newVersion, currentVersion, isLockFileMaintenance, ignoreFailure } = await parser.argv;
   let changelogBuffer;
   try {
     changelogBuffer = await fs.readFile(path);
@@ -59,7 +64,7 @@ const parser = yargs(process.argv.slice(2))
     throw new Error(`Unsupported changelog format "${format}"`);
   }
   try {
-    await fs.writeFile(path, changelogUpdater(changelogBuffer.toString(), depName, currentVersion, newVersion));
+    await fs.writeFile(path, changelogUpdater(changelogBuffer.toString(), depName, currentVersion, newVersion, isLockFileMaintenance));
   } catch (e) {
     if (!ignoreFailure) {
       throw e;

--- a/index.js
+++ b/index.js
@@ -44,6 +44,14 @@ const parser = yargs(process.argv.slice(2))
 
 (async () => {
   const { format, path, depName, newVersion, currentVersion, ignoreFailure } = await parser.argv;
+  
+  try {
+    await fs.access(path);
+  } catch (e) {
+    console.error('CHANGELOG.md not found. Exiting.');
+    process.exit(1);
+  }
+  
   let changelogBuffer;
   try {
     changelogBuffer = await fs.readFile(path);

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
-  "name": "renovate-changelog-updater",
-  "version": "1.1.4",
+  "name": "umbralab-renovate-changelog-updater",
+  "version": "2.0.0",
   "description": "Automatic changelog update for dependency updates",
   "main": "index.js",
-  "bin": "index.js",
+  "bin": {
+    "beforster-renovate-changelog-updater": "index.js"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ThibautMarechal/renovate-changelog-updater.git"
+    "url": "git+https://github.com/beforster/renovate-changelog-updater.git"
   },
   "scripts": {
     "ci": "npm-run-all lint check test",
@@ -20,6 +22,12 @@
     "update"
   ],
   "author": "Thibaut Maréchal",
+  "contributors": [
+    {
+      "name": "Ben Forster",
+      "email": "beforster1@gmail.com"
+    }
+  ],
   "license": "MIT",
   "devDependencies": {
     "@thimar/eslint-config": "^2.0.1",
@@ -35,5 +43,9 @@
   "dependencies": {
     "keep-a-changelog": "^2.1.0",
     "yargs": "^17.6.2"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/beforster/renovate-changelog-updater/issues"
+  },
+  "homepage": "https://github.com/beforster/renovate-changelog-updater#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umbralab-renovate-changelog-updater",
-  "version": "3.0.0",
+  "version": "2.1.1-dev",
   "description": "Automatic changelog update for dependency updates",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umbralab-renovate-changelog-updater",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Automatic changelog update for dependency updates",
   "main": "index.js",
   "bin": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/beforster/renovate-changelog-updater.git"
+    "url": "git+https://github.com/UmbraLabInc/renovate-changelog-updater.git"
   },
   "scripts": {
     "ci": "npm-run-all lint check test",
@@ -42,10 +42,11 @@
   },
   "dependencies": {
     "keep-a-changelog": "^2.1.0",
+    "semver": "^7.6.3",
     "yargs": "^17.6.2"
   },
   "bugs": {
-    "url": "https://github.com/beforster/renovate-changelog-updater/issues"
+    "url": "https://github.com/UmbraLabInc/renovate-changelog-updater/issues"
   },
-  "homepage": "https://github.com/beforster/renovate-changelog-updater#readme"
+  "homepage": "https://github.com/UmbraLabInc/renovate-changelog-updater#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umbralab-renovate-changelog-updater",
-  "version": "2.1.2-dev",
+  "version": "3.0.0",
   "description": "Automatic changelog update for dependency updates",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umbralab-renovate-changelog-updater",
-  "version": "2.1.1-dev",
+  "version": "2.1.2-dev",
   "description": "Automatic changelog update for dependency updates",
   "main": "index.js",
   "bin": {

--- a/updaters/index.js
+++ b/updaters/index.js
@@ -2,7 +2,7 @@
 
 const { updater: keepAChangelogUpdater } = require('./keep-a-changelog');
 
-/** @type {Record<string, (changelog: string, depName: string, currentversion: string, newVersion: string) => string>} */
+/** @type {Record<string, (changelog: string, depName: string, currentversion: string, newVersion: string, isLockFileMaintenance: boolean) => string>} */
 module.exports = {
   'keep-a-changelog': keepAChangelogUpdater,
 };

--- a/updaters/keep-a-changelog.js
+++ b/updaters/keep-a-changelog.js
@@ -65,7 +65,7 @@ function keepAChangelogUpdater(changelogRaw, depName, currentVersion, newVersion
   
   // Only proceed if the change description is valid (non-null)
   if (changeDescription !== null) {
-    let dependencyChange = unReleased.changes.get(category)?.find((change) => change.title.match(new RegExp(`^${dependencyListTitle}\\n?`)));
+    let dependendyChanged = unReleased.changes.get(category)?.find((change) => change.title.match(new RegExp(`^${dependencyListTitle}\\n?`)));
     if (!dependendyChanged) {
       dependendyChanged = new Change(`${dependencyListTitle}\n${changeDescription}`);
       unReleased.addChange(category, dependendyChanged);  

--- a/updaters/keep-a-changelog.js
+++ b/updaters/keep-a-changelog.js
@@ -21,6 +21,25 @@ function getChangeDescription(depName, currentVersion, newVersion) {
 }
 
 /**
+ * Determines the semver category for the version change.
+ *
+ * @param {string} currentVersion
+ * @param {string} newVersion
+ * @returns {'changed' | 'added' | 'fixed'}
+ */
+function getSemverCategory(currentVersion, newVersion) {
+  if (semver.diff(currentVersion, newVersion) === 'major') {
+    return 'changed';
+  } else if (semver.diff(currentVersion, newVersion) === 'minor') {
+    return 'added';
+  } else if (semver.diff(currentVersion, newVersion) === 'patch') {
+    return 'fixed';
+  } else {
+    return 'changed';
+  }
+}
+
+/**
  * @param {string} changelogRaw
  * @param {string} depName
  * @param {string} currentVersion
@@ -38,17 +57,17 @@ function keepAChangelogUpdater(changelogRaw, depName, currentVersion, newVersion
   } else {
     unReleased = firstRelease;
   }
-
-  const changedEntries = unReleased.changes.get('changed');
   
   // Regular behavior for other dependencies
-  let dependendyChanged = changedEntries?.find((changed) => changed.title.match(new RegExp(`^${dependencyListTitle}\n?`)));
+  const category = getSemverCategory(currentVersion, newVersion);
   const changeDescription = getChangeDescription(depName, currentVersion, newVersion);
+  
   // Only proceed if the change description is valid (non-null)
   if (changeDescription !== null) {
+    let dependencyChange = unReleased.changes.get(category)?.find((change) => change.title.match(new RegExp(`^${dependencyListTitle}\\n?`)));
     if (!dependendyChanged) {
-      dependendyChanged = new Change(`${dependencyListTitle}\n${getChangeDescription(depName, currentVersion, newVersion)}`);
-      unReleased.addChange('changed', dependendyChanged);  
+      dependendyChanged = new Change(`${dependencyListTitle}\n${changeDescription}`);
+      unReleased.addChange(category, dependendyChanged);  
     } else {
       let alreadyUpdated = false;
       const dependencyChangeRegex = /^(.*):\s(.*)\s->\s([^\\\s]*)\\?$/;
@@ -69,7 +88,7 @@ function keepAChangelogUpdater(changelogRaw, depName, currentVersion, newVersion
         }
       }
       if (!alreadyUpdated) {
-        dependendyChanged.title += `\n${getChangeDescription(depName, currentVersion, newVersion)}`;
+        dependendyChanged.title += `\n${changeDescription}`;
       }
     }
   dependendyChanged.title = dependendyChanged.title.replace(/\\$/g, '');

--- a/updaters/keep-a-changelog.js
+++ b/updaters/keep-a-changelog.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 const { Release, Change, parser: keepAChangelogParser } = require('keep-a-changelog');
+const semver = require('semver'); // Add semver for version comparison
 
 const dependencyListTitle = 'Dependency updates\\';
 const terraformMaintenanceTitle = 'Lock file maintenance';

--- a/updaters/keep-a-changelog.test.js
+++ b/updaters/keep-a-changelog.test.js
@@ -6,7 +6,7 @@ const { Changelog, Release } = require('keep-a-changelog');
 const depName = 'my-awesome-dependency';
 
 it('add the "UnReleased" released if not exist', () => {
-  expect(updater(new Changelog('My changelog').toString(), depName, '0', '1')).toMatchInlineSnapshot(`
+  expect(updater(new Changelog('My changelog').toString(), depName, '0', '1', false)).toMatchInlineSnapshot(`
     "# My changelog
 
     All notable changes to this project will be documented in this file.
@@ -27,7 +27,7 @@ it('add the changed to the already existing "UnReleased"section', () => {
   const release = new Release();
   release.addChange('fixed', 'some fixes');
   changelog.addRelease(release);
-  expect(updater(changelog.toString(), depName, '0', '1')).toMatchInlineSnapshot(`
+  expect(updater(changelog.toString(), depName, '0', '1', false)).toMatchInlineSnapshot(`
     "# My Changelog
 
     All notable changes to this project will be documented in this file.
@@ -46,36 +46,12 @@ it('add the changed to the already existing "UnReleased"section', () => {
   `);
 });
 
-it('add the changed to the already existing "UnReleased"section', () => {
-  const changelog = new Changelog('My Changelog');
-  const release = new Release();
-  release.addChange('fixed', 'some fixes');
-  changelog.addRelease(release);
-  expect(updater(changelog.toString(), depName, '0', '1')).toMatchInlineSnapshot(`
-    "# My Changelog
-
-    All notable changes to this project will be documented in this file.
-
-    The format is based on [Keep a Changelog](http://keepachangelog.com/)
-    and this project adheres to [Semantic Versioning](http://semver.org/).
-
-    ## Unreleased
-    ### Changed
-    - Dependency updates\\
-      my-awesome-dependency: 0 -> 1
-
-    ### Fixed
-    - some fixes
-    "
-  `);
-});
-
-it('add the updated package to the dependency list if it already exist', () => {
+it('add the updated package to the dependency list if it already exists', () => {
   const changelog = new Changelog('My Changelog');
   const release = new Release();
   release.addChange('changed', 'Dependency updates\nanother-dependency: 4 -> 5');
   changelog.addRelease(release);
-  expect(updater(changelog.toString(), depName, '0', '1')).toMatchInlineSnapshot(`
+  expect(updater(changelog.toString(), depName, '0', '1', false)).toMatchInlineSnapshot(`
     "# My Changelog
 
     All notable changes to this project will be documented in this file.
@@ -92,12 +68,12 @@ it('add the updated package to the dependency list if it already exist', () => {
   `);
 });
 
-it('update the dependency list if it already exist', () => {
+it('update the dependency list if it already exists', () => {
   const changelog = new Changelog('My Changelog');
   const release = new Release();
   release.addChange('changed', `Dependency updates\n${depName}: 0 -> 1`);
   changelog.addRelease(release);
-  expect(updater(changelog.toString(), depName, '1', '2')).toMatchInlineSnapshot(`
+  expect(updater(changelog.toString(), depName, '1', '2', false)).toMatchInlineSnapshot(`
     "# My Changelog
 
     All notable changes to this project will be documented in this file.
@@ -113,12 +89,12 @@ it('update the dependency list if it already exist', () => {
   `);
 });
 
-it('doesnt remove line if someone messed up the dependency list updates', () => {
+it('doesn\'t remove lines if someone messed up the dependency list updates', () => {
   const changelog = new Changelog('My Changelog');
   const release = new Release();
   release.addChange('changed', `Dependency updates\nHello world!\nmy-another-dependency: 0 -> 1\\`);
   changelog.addRelease(release);
-  expect(updater(changelog.toString(), depName, '1', '2')).toMatchInlineSnapshot(`
+  expect(updater(changelog.toString(), depName, '1', '2', false)).toMatchInlineSnapshot(`
     "# My Changelog
 
     All notable changes to this project will be documented in this file.
@@ -132,6 +108,23 @@ it('doesnt remove line if someone messed up the dependency list updates', () => 
       Hello world!
       my-another-dependency: 0 -> 1\\
       my-awesome-dependency: 1 -> 2
+    "
+  `);
+});
+
+it('adds only one line for lock file maintenance', () => {
+  const changelog = new Changelog('My Changelog');
+  expect(updater(changelog.toString(), depName, '0', '1', true)).toMatchInlineSnapshot(`
+    "# My Changelog
+
+    All notable changes to this project will be documented in this file.
+
+    The format is based on [Keep a Changelog](http://keepachangelog.com/)
+    and this project adheres to [Semantic Versioning](http://semver.org/).
+
+    ## Unreleased
+    ### Changed
+    - Lock file maintenance
     "
   `);
 });


### PR DESCRIPTION
Previously, Renovate did not allow for a changelog to not exist when processing a repository. This change will permit the absence of a `CHANGELOG.md` file and exit cleanly without doing any work if one is not present.